### PR TITLE
Allow overriding Lambda & STS endpoints

### DIFF
--- a/km/api/client.go
+++ b/km/api/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/bsycorp/keymaster/km/util"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 )
@@ -27,7 +28,7 @@ func NewClient(target string) *Client {
 	_, disableSSL := os.LookupEnv("KM_DISABLE_SSL")
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
-			EndpointResolver: endpoints.ResolverFunc(EndpointResolver),
+			EndpointResolver: endpoints.ResolverFunc(util.EndpointResolver),
 			DisableSSL:       &disableSSL,
 		},
 		SharedConfigState: session.SharedConfigEnable,

--- a/km/api/client.go
+++ b/km/api/client.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"encoding/json"
+	"log"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
-	"log"
 )
 
 type Client struct {
@@ -16,12 +19,17 @@ type Client struct {
 	//    * Partial ARN - 123456789012:function:my-function.
 	FunctionName string
 	lambdaClient *lambda.Lambda
-	Debug int
+	Debug        int
 }
 
 func NewClient(target string) *Client {
 	c := new(Client)
+	_, disableSSL := os.LookupEnv("KM_DISABLE_SSL")
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			EndpointResolver: endpoints.ResolverFunc(EndpointResolver),
+			DisableSSL:       &disableSSL,
+		},
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 	c.FunctionName = target
@@ -31,7 +39,7 @@ func NewClient(target string) *Client {
 
 func (c *Client) Discovery(req *DiscoveryRequest) (*DiscoveryResponse, error) {
 	resp := new(DiscoveryResponse)
-	err := c.rpc(&Request{ Type: "discovery", Payload: req}, resp)
+	err := c.rpc(&Request{Type: "discovery", Payload: req}, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +48,7 @@ func (c *Client) Discovery(req *DiscoveryRequest) (*DiscoveryResponse, error) {
 
 func (c *Client) GetConfig(req *ConfigRequest) (*ConfigResponse, error) {
 	resp := new(ConfigResponse)
-	err := c.rpc(&Request{ Type: "config", Payload: req}, resp)
+	err := c.rpc(&Request{Type: "config", Payload: req}, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +61,7 @@ func (c *Client) DirectSamlAuth(req *DirectSamlAuthRequest) (*DirectAuthResponse
 
 func (c *Client) WorkflowStart(req *WorkflowStartRequest) (*WorkflowStartResponse, error) {
 	resp := new(WorkflowStartResponse)
-	err := c.rpc(&Request{ Type: "workflow_start", Payload: req}, resp)
+	err := c.rpc(&Request{Type: "workflow_start", Payload: req}, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +70,7 @@ func (c *Client) WorkflowStart(req *WorkflowStartRequest) (*WorkflowStartRespons
 
 func (c *Client) WorkflowAuth(req *WorkflowAuthRequest) (*WorkflowAuthResponse, error) {
 	resp := new(WorkflowAuthResponse)
-	err := c.rpc(&Request{ Type: "workflow_auth", Payload: req}, resp)
+	err := c.rpc(&Request{Type: "workflow_auth", Payload: req}, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +98,7 @@ func (c *Client) rpc(req interface{}, resp interface{}) error {
 	}
 	result, err := c.lambdaClient.Invoke(&lambda.InvokeInput{
 		FunctionName: aws.String(c.FunctionName),
-		Payload: payload,
+		Payload:      payload,
 	})
 	if err != nil {
 		return errors.Wrap(err, "rpc invoke")

--- a/km/api/resolver.go
+++ b/km/api/resolver.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/lambda"
+)
+
+func EndpointResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	if service == lambda.ServiceName && os.Getenv("KM_LAMBDA_ENDPOINT") != "" {
+		return endpoints.ResolvedEndpoint{
+			URL: os.Getenv("KM_LAMBDA_ENDPOINT"),
+		}, nil
+	}
+	return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+}

--- a/km/creds/issuer.go
+++ b/km/creds/issuer.go
@@ -1,11 +1,15 @@
 package creds
 
 import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/bsycorp/keymaster/km/api"
+	"github.com/bsycorp/keymaster/km/util"
 	"github.com/pkg/errors"
-	"log"
 )
 
 type issuer interface {
@@ -17,10 +21,9 @@ type Issuer struct {
 }
 
 func NewFromConfig(role *api.RoleConfig, config *api.Config) (*Issuer, error) {
-	sess, err := session.NewSession()
-	if err != nil {
-		return nil, err
-	}
+	sess := session.Must(session.NewSession(&aws.Config{
+		EndpointResolver: endpoints.ResolverFunc(util.EndpointResolver),
+	}))
 	var issuer Issuer
 	for _, credName := range role.Credentials {
 		credConfig := config.FindCredentialByName(credName)

--- a/km/util/resolver.go
+++ b/km/util/resolver.go
@@ -1,13 +1,19 @@
-package api
+package util
 
 import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 func EndpointResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	if service == sts.ServiceName && os.Getenv("KM_STS_ENDPOINT") != "" {
+		return endpoints.ResolvedEndpoint{
+			URL: os.Getenv("KM_STS_ENDPOINT"),
+		}, nil
+	}
 	if service == lambda.ServiceName && os.Getenv("KM_LAMBDA_ENDPOINT") != "" {
 		return endpoints.ResolvedEndpoint{
 			URL: os.Getenv("KM_LAMBDA_ENDPOINT"),


### PR DESCRIPTION
This lets the endpoints used for AWS Lambda & AWS STS be overridden by using the following environment variables:

- KM_STS_ENDPOINT
- KM_LAMBDA_ENDPOINT

Additionally you can set a KM_DISABLE_SSL to disable SSL on the lambda calls.

This change was made to facilitate doing full end-to-end testing of keymaster using stubs/mocks for the AWS components.