### PR TITLE
Adds --aws-set-profile-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For ci, you need to specify the usual issuer and target role,
 as well as details to identify the source of your access request.
 
 ```
-km --issuer <issuing-lambda> --role deployment \
+km ci --issuer <issuing-lambda> --role deployment \
   --username smithb12 \
   --name "Bob Smith" \
   --email "bob.smith@awesome.com" \

--- a/cmd/km/commands/root.go
+++ b/cmd/km/commands/root.go
@@ -15,6 +15,7 @@ var roleFlag string
 var debugFlag int
 
 var awsCredentialsFileFlag string
+var awsSetProfileNameFlag string
 
 var rootCmd = &cobra.Command{
 	Use:   "km",
@@ -45,6 +46,7 @@ func init() {
 	defaultAwsCredentialsFile := homeDir + "/.aws/credentials"
 
 	rootCmd.PersistentFlags().StringVar(&awsCredentialsFileFlag, "aws-credentials-file", defaultAwsCredentialsFile, "path to AWS credentials file")
+	rootCmd.PersistentFlags().StringVar(&awsSetProfileNameFlag, "aws-set-profile-name", "", "set AWS profile output name (e.g. 'default')")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.


### PR DESCRIPTION
This flag lets you force the name for your AWS profile.